### PR TITLE
Clip and Drawer own options menus

### DIFF
--- a/src/WindowMaker.h
+++ b/src/WindowMaker.h
@@ -576,6 +576,7 @@ extern struct wmaker_global_variables {
 		struct WMenu *pos_menu;	/* menu for position of the dock */
 		struct WMenu *dock_menu;	/* Dock menu */
 		struct WMenu *drawer_menu;	/* menu for the drawers */
+		struct WMenu *drawer_opt_menu;	/* Options for drawers */
 	} dock;
 
 	/* Drawers related */

--- a/src/dock.c
+++ b/src/dock.c
@@ -953,45 +953,44 @@ static WMenu *makeWorkspaceMenu(void)
 	return menu;
 }
 
-static void updateClipOptionsMenu(WDock *dock)
+static void updateOptionsMenu(WDock *dock, WMenu *menu)
 {
 	WMenuEntry *entry;
 	int index = 0;
 
-	if (!w_global.clip.opt_menu || !dock)
+	if (!menu || !dock)
 		return;
 
 	/* keep on top */
-	entry = w_global.clip.opt_menu->entries[index];
+	entry = menu->entries[index];
 	entry->flags.indicator_on = !dock->lowered;
 	entry->clientdata = dock;
-	wMenuSetEnabled(w_global.clip.opt_menu, index, dock->type == WM_CLIP);
+	wMenuSetEnabled(menu, index, dock->type == WM_CLIP);
 
 	/* collapsed */
-	entry = w_global.clip.opt_menu->entries[++index];
+	entry = menu->entries[++index];
 	entry->flags.indicator_on = dock->collapsed;
 	entry->clientdata = dock;
 
 	/* auto-collapse */
-	entry = w_global.clip.opt_menu->entries[++index];
+	entry = menu->entries[++index];
 	entry->flags.indicator_on = dock->auto_collapse;
 	entry->clientdata = dock;
 
 	/* auto-raise/lower */
-	entry = w_global.clip.opt_menu->entries[++index];
+	entry = menu->entries[++index];
 	entry->flags.indicator_on = dock->auto_raise_lower;
 	entry->clientdata = dock;
-	wMenuSetEnabled(w_global.clip.opt_menu, index, dock->lowered && (dock->type == WM_CLIP));
+	wMenuSetEnabled(menu, index, dock->lowered && (dock->type == WM_CLIP));
 
 	/* attract icons */
-	entry = w_global.clip.opt_menu->entries[++index];
+	entry = menu->entries[++index];
 	entry->flags.indicator_on = dock->attract_icons;
 	entry->clientdata = dock;
 
-	w_global.clip.opt_menu->flags.realized = 0;
-	wMenuRealize(w_global.clip.opt_menu);
+	menu->flags.realized = 0;
+	wMenuRealize(menu);
 }
-
 
 WMenu *makeClipOptionsMenu(void)
 {
@@ -1268,7 +1267,7 @@ static void drawer_menu_create(void)
 
 	entry = wMenuAddCallback(menu, _("Drawer options"), NULL, NULL);
 
-	wMenuEntrySetCascade_create(menu, entry, w_global.clip.opt_menu);
+	wMenuEntrySetCascade_create(menu, entry, w_global.dock.drawer_opt_menu);
 
 	entry = wMenuAddCallback(menu, _("Selected"), selectCallback, NULL);
 	entry->flags.indicator = 1;
@@ -1308,19 +1307,17 @@ static void drawer_menu_map(WMenu *menu, WScreen *scr)
 {
 	menu_map(menu, scr);
 
-	/* This code is shared with the Clip
-	 * if the clip was created, we don't need do it again */
-	if ((w_global.clip.opt_menu) && (wPreferences.flags.noclip)) {
-		menu_map(w_global.clip.opt_menu, scr);
-		wMenuRealize(w_global.clip.opt_menu);
+	if (w_global.dock.drawer_opt_menu) {
+		menu_map(w_global.dock.drawer_opt_menu, scr);
+		wMenuRealize(w_global.dock.drawer_opt_menu);
 	}
 
-	wMenuEntrySetCascade_map(menu, w_global.clip.opt_menu);
+	wMenuEntrySetCascade_map(menu, w_global.dock.drawer_opt_menu);
 }
 
 static void drawer_menu_unmap(WMenu *menu)
 {
-	menu_unmap(w_global.clip.opt_menu);
+	menu_unmap(w_global.dock.drawer_opt_menu);
 	menu_unmap(menu);
 }
 
@@ -3831,36 +3828,34 @@ static void set_dockmenu_dock_code(WDock *dock, WMenuEntry *entry, WAppIcon *aic
 	}
 }
 
-static void set_dockmenu_clipdrawer_code(WDock *dock, WMenuEntry *entry, WAppIcon *aicon, int *index)
+static void set_dockmenu_clip_code(WDock *dock, WMenuEntry *entry, WAppIcon *aicon, int *index)
 {
 	int n_selected;
 
 	/* clip/drawer options */
 	if (w_global.clip.opt_menu)
-		updateClipOptionsMenu(dock);
+		updateOptionsMenu(dock, w_global.clip.opt_menu);
 
 	n_selected = numberOfSelectedIcons(dock);
 
-	if (dock->type == WM_CLIP) {
-		/* Rename Workspace */
-		entry = dock->menu->entries[++(*index)];
-		if (aicon == w_global.clip.icon) {
-			entry->callback = renameCallback;
-			entry->clientdata = dock;
+	/* Rename Workspace */
+	entry = dock->menu->entries[++(*index)];
+	if (aicon == w_global.clip.icon) {
+		entry->callback = renameCallback;
+		entry->clientdata = dock;
+		entry->flags.indicator = 0;
+		entry->text = _("Rename Workspace");
+	} else {
+		entry->callback = omnipresentCallback;
+		entry->clientdata = aicon;
+		if (n_selected > 0) {
 			entry->flags.indicator = 0;
-			entry->text = _("Rename Workspace");
+			entry->text = _("Toggle Omnipresent");
 		} else {
-			entry->callback = omnipresentCallback;
-			entry->clientdata = aicon;
-			if (n_selected > 0) {
-				entry->flags.indicator = 0;
-				entry->text = _("Toggle Omnipresent");
-			} else {
-				entry->flags.indicator = 1;
-				entry->flags.indicator_on = aicon->omnipresent;
-				entry->flags.indicator_type = MI_CHECK;
-				entry->text = _("Omnipresent");
-			}
+			entry->flags.indicator = 1;
+			entry->flags.indicator_on = aicon->omnipresent;
+			entry->flags.indicator_type = MI_CHECK;
+			entry->text = _("Omnipresent");
 		}
 	}
 
@@ -3890,19 +3885,71 @@ static void set_dockmenu_clipdrawer_code(WDock *dock, WMenuEntry *entry, WAppIco
 
 	wMenuSetEnabled(dock->menu, *index, dock->icon_count > 1);
 
-	if (dock->type == WM_CLIP) {
-		/* this is the workspace submenu part */
-		entry = dock->menu->entries[++(*index)];
-		if (n_selected > 1)
-			entry->text = _("Move Icons To");
-		else
-			entry->text = _("Move Icon To");
+	/* this is the workspace submenu part */
+	entry = dock->menu->entries[++(*index)];
+	if (n_selected > 1)
+		entry->text = _("Move Icons To");
+	else
+		entry->text = _("Move Icon To");
 
-		if (w_global.clip.submenu)
-			updateWorkspaceMenu(w_global.clip.submenu, aicon);
+	if (w_global.clip.submenu)
+		updateWorkspaceMenu(w_global.clip.submenu, aicon);
 
-		wMenuSetEnabled(dock->menu, *index, !aicon->omnipresent);
-	}
+	wMenuSetEnabled(dock->menu, *index, !aicon->omnipresent);
+
+	/* remove icon(s) */
+	entry = dock->menu->entries[++(*index)];
+	entry->clientdata = aicon;
+	if (n_selected > 1)
+		entry->text = _("Remove Icons");
+	else
+		entry->text = _("Remove Icon");
+
+	wMenuSetEnabled(dock->menu, *index, dock->icon_count > 1);
+
+	/* attract icon(s) */
+	entry = dock->menu->entries[++(*index)];
+	entry->clientdata = aicon;
+
+	dock->menu->flags.realized = 0;
+	wMenuRealize(dock->menu);
+}
+
+static void set_dockmenu_drawer_code(WDock *dock, WMenuEntry *entry, WAppIcon *aicon, int *index)
+{
+	int n_selected;
+
+	/* clip/drawer options */
+	if (w_global.dock.drawer_opt_menu)
+		updateOptionsMenu(dock, w_global.dock.drawer_opt_menu);
+
+	n_selected = numberOfSelectedIcons(dock);
+
+	/* select/unselect icon */
+	entry = dock->menu->entries[++(*index)];
+	entry->clientdata = aicon;
+	entry->flags.indicator_on = aicon->icon->selected;
+	wMenuSetEnabled(dock->menu, *index, aicon != w_global.clip.icon && !wIsADrawer(aicon));
+
+	/* select/unselect all icons */
+	entry = dock->menu->entries[++(*index)];
+	entry->clientdata = aicon;
+	if (n_selected > 0)
+		entry->text = _("Unselect All Icons");
+	else
+		entry->text = _("Select All Icons");
+
+	wMenuSetEnabled(dock->menu, *index, dock->icon_count > 1);
+
+	/* keep icon(s) */
+	entry = dock->menu->entries[++(*index)];
+	entry->clientdata = aicon;
+	if (n_selected > 1)
+		entry->text = _("Keep Icons");
+	else
+		entry->text = _("Keep Icon");
+
+	wMenuSetEnabled(dock->menu, *index, dock->icon_count > 1);
 
 	/* remove icon(s) */
 	entry = dock->menu->entries[++(*index)];
@@ -3999,7 +4046,7 @@ static void open_menu_dock(WDock *dock, WAppIcon *aicon, XEvent *event)
 	(*desc->handle_mousedown) (desc, event);
 }
 
-static void open_menu_clipdrawer(WDock *dock, WAppIcon *aicon, XEvent *event)
+static void open_menu_clip(WDock *dock, WAppIcon *aicon, XEvent *event)
 {
 	WScreen *scr = dock->screen_ptr;
 	WObjDescriptor *desc;
@@ -4007,7 +4054,35 @@ static void open_menu_clipdrawer(WDock *dock, WAppIcon *aicon, XEvent *event)
 	int index = 0;
 	int x_pos;
 
-	set_dockmenu_clipdrawer_code(dock, entry, aicon, &index);
+	set_dockmenu_clip_code(dock, entry, aicon, &index);
+	set_dockmenu_common_code(dock, entry, aicon, &index);
+
+	if (!dock->menu->flags.realized)
+		wMenuRealize(dock->menu);
+
+	x_pos = event->xbutton.x_root - dock->menu->frame->core->width / 2 - 1;
+	if (x_pos < 0)
+		x_pos = 0;
+	else if (x_pos + dock->menu->frame->core->width > scr->scr_width - 2)
+		x_pos = scr->scr_width - dock->menu->frame->core->width - 4;
+
+	wMenuMapAt(dock->menu, x_pos, event->xbutton.y_root + 2, False);
+
+	/* allow drag select */
+	event->xany.send_event = True;
+	desc = &dock->menu->menu->descriptor;
+	(*desc->handle_mousedown) (desc, event);
+}
+
+static void open_menu_drawer(WDock *dock, WAppIcon *aicon, XEvent *event)
+{
+	WScreen *scr = dock->screen_ptr;
+	WObjDescriptor *desc;
+	WMenuEntry *entry;
+	int index = 0;
+	int x_pos;
+
+	set_dockmenu_drawer_code(dock, entry, aicon, &index);
 	set_dockmenu_common_code(dock, entry, aicon, &index);
 
 	if (!dock->menu->flags.realized)
@@ -4458,12 +4533,12 @@ static void iconMouseDown(WObjDescriptor *desc, XEvent *event)
 			break;
 		case WM_CLIP:
 			clip_menu_map(dock->menu, scr);
-			open_menu_clipdrawer(dock, aicon, event);
+			open_menu_clip(dock, aicon, event);
 			clip_menu_unmap(dock->menu);
 			break;
 		case WM_DRAWER:
 			drawer_menu_map(dock->menu, scr);
-			open_menu_clipdrawer(dock, aicon, event);
+			open_menu_drawer(dock, aicon, event);
 			drawer_menu_unmap(dock->menu);
 		}
 	}

--- a/src/startup.c
+++ b/src/startup.c
@@ -629,6 +629,7 @@ void StartUp(Bool defaultScreenOnly)
 	w_global.dock.pos_menu = makeDockPositionMenu();
 	w_global.clip.opt_menu = makeClipOptionsMenu();
 	w_global.dock.dock_menu = dock_menu_create();
+	w_global.dock.drawer_opt_menu = makeClipOptionsMenu();
 
 	/* Create the dock */
 	if (!wPreferences.flags.nodock)


### PR DESCRIPTION
This patch creates own options menus for the Clip and for the Drawers.

There is a problem (bug) included in the patch
1c373cb8c4ca52358f79ae10fee0cf78e4ef3723
Title: DA: Clip and drawer menu always unmapped (warning)
that creates a common menu for the Clip and for the Drawer. Then, when
the user calls the Drawer menu (right click on Drawer) wmaker try to
call these lines:

static void updateClipOptionsMenu(WDock *dock)
{
...
    if (!w_global.clip.opt_menu || !dock)
        return;

For the Drawer, then, the function doesn't return, and wmaker crash
because the funcion at the end of this function:
  wMenuRealize(w_global.clip.opt_menu);
calls the function wcore_map with a non initialized screen (screen_ptr is 0x0).

This patch split the common functions for Clip and Drawer, and the
problem is gone. The patch includes the new drawer_opt_menu variable
in the w_global variable. The variable is included in the Dock, because
is common for all drawers and drawers depends on Dock (no Dock, no Drawers).

This patch solves a BUG (wmaker crash).
