### PR TITLE
BUG: Bug with focusing method

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -1149,7 +1149,7 @@ static void handleEnterNotify(XEvent *event)
 			if (wPreferences.raise_delay && !WFLAGP(wwin, no_focusable)) {
 				vscr->screen_ptr->autoRaiseWindow = wwin->frame->core->window;
 				vscr->screen_ptr->autoRaiseTimer
-				    = WMAddTimerHandler(wPreferences.raise_delay, (WMCallback *) raiseWindow, vscr->screen_ptr);
+				    = WMAddTimerHandler(wPreferences.raise_delay, (WMCallback *) raiseWindow, vscr);
 			}
 		}
 		/* Install colormap for window, if the colormap installation mode


### PR DESCRIPTION
This patch solves a problem with focusing method. The patch

..
Date: Wed, 3 Dec 2014 20:40:01 +0100
Subject: [PATCH 035/250] VSCR: event.c static functions without WScreen

This patch changes the WScreen static functions with the virtual_screen
variable.
..

pass as argument the WScreen struct instead of the virtual_screen.