### PR TITLE
Remove framewin title variable

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -1169,7 +1169,7 @@ static WWindow *recursiveTransientFor(WWindow *wwin)
 
 	if (i == 0 && wwin) {
 		wwarning(_("window \"%s\" has a severely broken WM_TRANSIENT_FOR hint"),
-			 wwin->frame->title);
+			 wwin->title);
 		return NULL;
 	}
 

--- a/src/actions.c
+++ b/src/actions.c
@@ -256,7 +256,7 @@ void wShadeWindow(WWindow *wwin)
 	/* for the client it's just like iconification */
 	wFrameWindowResize(wwin->frame, wwin->frame->core->width, wwin->frame->top_width - 1);
 
-	wwin->client.y = wwin->frame_y - wwin->client.height + wwin->frame->top_width;
+	wwin->client.y = wwin->frame_y - wwin->height + wwin->frame->top_width;
 	wWindowSynthConfigureNotify(wwin);
 
 	/*
@@ -286,7 +286,7 @@ void wUnshadeWindow(WWindow *wwin)
 
 	wwin->flags.skip_next_animation = 0;
 	wFrameWindowResize(wwin->frame, wwin->frame->core->width,
-			   wwin->frame->top_width + wwin->client.height + wwin->frame->bottom_width);
+			   wwin->frame->top_width + wwin->height + wwin->frame->bottom_width);
 
 	wwin->client.y = wwin->frame_y + wwin->frame->top_width;
 	wWindowSynthConfigureNotify(wwin);
@@ -313,9 +313,9 @@ static void save_old_geometry(WWindow *wwin, int directions)
 	if (directions & SAVE_GEOMETRY_Y)
 		wwin->old_geometry.y = wwin->frame_y;
 	if (directions & SAVE_GEOMETRY_WIDTH)
-		wwin->old_geometry.width = wwin->client.width;
+		wwin->old_geometry.width = wwin->width;
 	if (directions & SAVE_GEOMETRY_HEIGHT)
-		wwin->old_geometry.height = wwin->client.height;
+		wwin->old_geometry.height = wwin->height;
 }
 
 static void remember_geometry(WWindow *wwin, int *x, int *y, int *w, int *h)
@@ -329,8 +329,8 @@ static void remember_geometry(WWindow *wwin, int *x, int *y, int *w, int *h)
 	same_head = (wGetHeadForWindow(wwin) == old_head);
 	*x = ((wwin->old_geometry.x || wwin->old_geometry.width) && same_head) ? wwin->old_geometry.x : wwin->frame_x;
 	*y = ((wwin->old_geometry.y || wwin->old_geometry.height) && same_head) ? wwin->old_geometry.y : wwin->frame_y;
-	*w = wwin->old_geometry.width ? wwin->old_geometry.width : wwin->client.width;
-	*h = wwin->old_geometry.height ? wwin->old_geometry.height : wwin->client.height;
+	*w = wwin->old_geometry.width ? wwin->old_geometry.width : wwin->width;
+	*h = wwin->old_geometry.height ? wwin->old_geometry.height : wwin->height;
 }
 
 /* Remember geometry for unmaximizing */
@@ -2041,8 +2041,8 @@ void movePionterToWindowCenter(WWindow *wwin)
 
 	XSelectInput(dpy, wwin->client_win, wwin->event_mask);
 	XWarpPointer(dpy, None, wwin->vscr->screen_ptr->root_win, 0, 0, 0, 0,
-			wwin->frame_x + wwin->client.width / 2,
-			wwin->frame_y + wwin->client.height / 2);
+			wwin->frame_x + wwin->width / 2,
+			wwin->frame_y + wwin->height / 2);
 	XFlush(dpy);
 }
 
@@ -2093,7 +2093,7 @@ static void shade_animate(WWindow *wwin, Bool what)
 
 	case UNSHADE:
 		h = wwin->frame->top_width + wwin->frame->bottom_width;
-		y = wwin->frame->top_width - wwin->client.height;
+		y = wwin->frame->top_width - wwin->height;
 		s = abs(y) / SHADE_STEPS;
 		if (s < 1)
 			s = 1;
@@ -2101,7 +2101,7 @@ static void shade_animate(WWindow *wwin, Bool what)
 		w = wwin->frame->core->width;
 		XMoveWindow(dpy, wwin->client_win, 0, y);
 		if (s > 0) {
-			while (h < wwin->client.height + wwin->frame->top_width + wwin->frame->bottom_width) {
+			while (h < wwin->height + wwin->frame->top_width + wwin->frame->bottom_width) {
 				XResizeWindow(dpy, wwin->frame->core->window, w, h);
 				XMoveWindow(dpy, wwin->client_win, 0, y);
 				XFlush(dpy);

--- a/src/balloon.c
+++ b/src/balloon.c
@@ -483,13 +483,13 @@ static void miniwindowBalloon(WObjDescriptor *object)
 	virtual_screen *vscr = icon->core->vscr;
 	WScreen *scr = vscr->screen_ptr;
 
-	if (!icon->icon_name) {
+	if (!icon->title) {
 		wBalloonHide(vscr);
 		return;
 	}
 
 	scr->balloon->h = icon->core->height;
-	scr->balloon->text = wstrdup(icon->icon_name);
+	scr->balloon->text = wstrdup(icon->title);
 	scr->balloon->mini_preview = icon->mini_preview;
 	scr->balloon->objectWindow = icon->core->window;
 

--- a/src/framewin.c
+++ b/src/framewin.c
@@ -71,12 +71,15 @@ static void allocFrameBorderPixel(Colormap colormap, const char *color_name, uns
 		**pixel = xcol.pixel;
 }
 
-WFrameWindow *wframewindow_create(int width, int height, int flags)
+WFrameWindow *wframewindow_create(WWindow *parent_wwin, WMenu *parent_wmenu,
+				  int width, int height, int flags)
 {
 	WFrameWindow *fwin;
 
 	fwin = wmalloc(sizeof(WFrameWindow));
 	fwin->core = wcore_create(width, height);
+	fwin->parent_wwin = parent_wwin;
+	fwin->parent_wmenu = parent_wmenu;
 
 	fwin->flags.map_titlebar = (flags & WFF_TITLEBAR) ? 1 : 0;
 	fwin->flags.map_resizebar = (flags & WFF_RESIZEBAR) ? 1 : 0;

--- a/src/framewin.h
+++ b/src/framewin.h
@@ -24,6 +24,8 @@
 #include "wcore.h"
 #include "pixmap.h"
 #include "texture.h"
+#include "menu.h"
+#include "window.h"
 
 #define BORDER_TOP	1
 #define BORDER_BOTTOM	2
@@ -48,6 +50,9 @@
 
 typedef struct WFrameWindow {
     virtual_screen *vscr;	       /* pointer to the virtual screen structure */
+
+    WWindow *parent_wwin;               /* Parent WWindow */
+    WMenu *parent_wmenu;                /* Parent WMenu */
 
     WCoreWindow *core;
 
@@ -184,7 +189,8 @@ void wframewindow_refresh_titlebar(WFrameWindow *fwin);
 void wFrameWindowUpdateLanguageButton(WFrameWindow *fwin);
 #endif
 
-WFrameWindow *wframewindow_create(int width, int height, int flags);
+WFrameWindow *wframewindow_create(WWindow *parent_wwin, WMenu *parent_wmenu,
+				  int width, int height, int flags);
 void wframewindow_map(WFrameWindow *fwin, virtual_screen *vscr, int wlevel,
                       int x, int y, int *clearance,
                       int *title_min, int *title_max,

--- a/src/framewin.h
+++ b/src/framewin.h
@@ -94,8 +94,6 @@ typedef struct WFrameWindow {
     WMColor **title_color;
     WMFont **font;
 
-    char *title;		       /* window name (title) */
-
 #ifdef KEEP_XKB_LOCK_STATUS
     int languagemode;
     int last_languagemode;

--- a/src/icon.c
+++ b/src/icon.c
@@ -996,8 +996,8 @@ static void create_minipreview_showerror(WWindow *wwin)
 	const char *title;
 	char title_buf[32];
 
-	if (wwin->frame->title) {
-		title = wwin->frame->title;
+	if (wwin->title) {
+		title = wwin->title;
 	} else {
 		snprintf(title_buf, sizeof(title_buf), "(id=0x%lx)", wwin->client_win);
 		title = title_buf;

--- a/src/icon.c
+++ b/src/icon.c
@@ -978,7 +978,7 @@ int create_icon_minipreview(WWindow *wwin)
 	int ret;
 
 	ret = create_minipixmap_for_wwindow(wwin->vscr, wwin, &pixmap);
-	if (!ret) {
+	if (ret) {
 		create_minipreview_showerror(wwin);
 		return -1;
 	}

--- a/src/icon.c
+++ b/src/icon.c
@@ -221,8 +221,8 @@ void wIconDestroy(WIcon *icon)
 		XReparentWindow(dpy, icon->icon_win, scr->root_win, x, y);
 	}
 
-	if (icon->icon_name)
-		wfree(icon->icon_name);
+	if (icon->title)
+		wfree(icon->title);
 
 	if (icon->pixmap)
 		XFreePixmap(dpy, icon->pixmap);
@@ -325,10 +325,10 @@ void wIconChangeTitle(WIcon *icon, WWindow *wwin)
 	if (!icon || !wwin)
 		return;
 
-	if (icon->icon_name)
-		wfree(icon->icon_name);
+	if (icon->title)
+		wfree(icon->title);
 
-	icon->icon_name = wstrdup(wwin->title);
+	icon->title = wstrdup(wwin->title);
 }
 
 RImage *wIconValidateIconSize(RImage *icon, int max_size)
@@ -790,8 +790,8 @@ static void update_icon_title(WIcon *icon)
 	char *tmp;
 
 	/* draw the icon title */
-	if (icon->show_title && icon->icon_name != NULL) {
-		tmp = ShrinkString(scr->icon_title_font, icon->icon_name, wPreferences.icon_size - 4);
+	if (icon->show_title && icon->title != NULL) {
+		tmp = ShrinkString(scr->icon_title_font, icon->title, wPreferences.icon_size - 4);
 		w = WMWidthOfString(scr->icon_title_font, tmp, l = strlen(tmp));
 
 		if (w > icon->core->width - 4)

--- a/src/icon.h
+++ b/src/icon.h
@@ -35,7 +35,7 @@
 typedef struct WIcon {
 	WCoreWindow 	*core;
 	WWindow 	*owner;		/* owner window */
-	char 		*icon_name;	/* the icon name hint */
+	char 		*title;		/* the icon name hint */
 
 	Window 		icon_win;	/* client suplied icon window */
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -143,7 +143,7 @@ WMenu *menu_create(const char *title)
 		flags |= WFF_TITLEBAR | WFF_RIGHT_BUTTON;
 
 	menu = wmalloc(sizeof(WMenu));
-	menu->frame = wframewindow_create(width, 1, flags);
+	menu->frame = wframewindow_create(NULL, menu, width, 1, flags);
 	menu->menu = wcore_create(width, 10);
 
 	if (title) {

--- a/src/menu.c
+++ b/src/menu.c
@@ -148,6 +148,7 @@ WMenu *menu_create(const char *title)
 
 	if (title) {
 		menu->frame->title = wstrdup(title);
+		menu->title = wstrdup(title);
 		menu->flags.titled = 1;
 	}
 
@@ -191,6 +192,9 @@ void menu_destroy(WMenu *menu)
 
         if (menu->menu->stacking)
                 wfree(menu->menu->stacking);
+
+        if (menu->title)
+                wfree(menu->title);
 
         wcore_destroy(menu->menu);
 	wFrameWindowDestroy(menu->frame);
@@ -451,7 +455,7 @@ void wMenuRealize(WMenu *menu)
 	wframewin_set_borders(menu->frame, flags);
 
 	if (menu->flags.titled) {
-		twidth = WMWidthOfString(scr->menu_title_font, menu->frame->title, strlen(menu->frame->title));
+		twidth = WMWidthOfString(scr->menu_title_font, menu->title, strlen(menu->title));
 		theight = menu->frame->top_width;
 		twidth += theight + (wPreferences.new_style == TS_NEW ? 16 : 8);
 	}
@@ -2127,10 +2131,10 @@ static Bool getMenuPath(WMenu *menu, char *buffer, int bufSize)
 	Bool ok = True;
 	int len = 0;
 
-	if (!menu->flags.titled || !menu->frame->title[0])
+	if (!menu->flags.titled || !menu->title[0])
 		return False;
 
-	len = strlen(menu->frame->title);
+	len = strlen(menu->title);
 	if (len >= bufSize)
 		return False;
 
@@ -2141,7 +2145,7 @@ static Bool getMenuPath(WMenu *menu, char *buffer, int bufSize)
 	}
 
 	strcat(buffer, "\\");
-	strcat(buffer, menu->frame->title);
+	strcat(buffer, menu->title);
 
 	return True;
 }
@@ -2254,10 +2258,10 @@ static int restoreMenuRecurs(virtual_screen *vscr, WMPropList *menus, WMenu *men
 	int i, x, y, res, width, height;
 	Bool lowered;
 
-	if (strlen(path) + strlen(menu->frame->title) > 510)
+	if (strlen(path) + strlen(menu->title) > 510)
 		return False;
 
-	snprintf(buffer, sizeof(buffer), "%s\\%s", path, menu->frame->title);
+	snprintf(buffer, sizeof(buffer), "%s\\%s", path, menu->title);
 	key = WMCreatePLString(buffer);
 	entry = WMGetFromPLDictionary(menus, key);
 	res = False;

--- a/src/menu.c
+++ b/src/menu.c
@@ -147,7 +147,6 @@ WMenu *menu_create(const char *title)
 	menu->menu = wcore_create(width, 10);
 
 	if (title) {
-		menu->frame->title = wstrdup(title);
 		menu->title = wstrdup(title);
 		menu->flags.titled = 1;
 	}

--- a/src/menu.h
+++ b/src/menu.h
@@ -50,6 +50,7 @@ typedef struct WMenuEntry {
 } WMenuEntry;
 
 typedef struct WMenu {
+	char *title;				/* Menu title */
 	struct WMenu *parent;
 
 	time_t timestamp;			/* for the root menu. Last time

--- a/src/moveres.c
+++ b/src/moveres.c
@@ -1993,20 +1993,20 @@ static int getResizeDirection(WWindow * wwin, int x, int y, int dy, int flags)
 	/* if not resizing through the resizebar */
 	if (!(flags & RESIZEBAR)) {
 
-		int xdir = (abs(x) < (wwin->client.width / 2)) ? LEFT : RIGHT;
-		int ydir = (abs(y) < (wwin->client.height / 2)) ? UP : DOWN;
+		int xdir = (abs(x) < (wwin->width / 2)) ? LEFT : RIGHT;
+		int ydir = (abs(y) < (wwin->height / 2)) ? UP : DOWN;
 
 		/* How much resize space is allowed */
-		int spacew = abs(wwin->client.width / 3);
-		int spaceh = abs(wwin->client.height / 3);
+		int spacew = abs(wwin->width / 3);
+		int spaceh = abs(wwin->height / 3);
 
 		/* Determine where x fits */
-		if ((abs(x) > wwin->client.width/2 - spacew/2) &&
-		    (abs(x) < wwin->client.width/2 + spacew/2)) {
+		if ((abs(x) > wwin->width/2 - spacew/2) &&
+		    (abs(x) < wwin->width/2 + spacew/2)) {
 			/* Resize vertically */
 			xdir = 0;
-		} else if ((abs(y) > wwin->client.height/2 - spaceh/2) &&
-		           (abs(y) < wwin->client.height/2 + spaceh/2)) {
+		} else if ((abs(y) > wwin->height/2 - spaceh/2) &&
+		           (abs(y) < wwin->height/2 + spaceh/2)) {
 			/* Resize horizontally */
 			ydir = 0;
 		}

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1553,7 +1553,7 @@ static void configure_menu_entries(virtual_screen *vscr, WMPropList *definition,
 			/* submenu */
 			submenu = configureMenu(vscr, elem);
 			if (submenu) {
-				mentry = wMenuAddCallback(menu, submenu->frame->title, NULL, NULL);
+				mentry = wMenuAddCallback(menu, submenu->title, NULL, NULL);
 				wMenuEntrySetCascade_create(menu, mentry, submenu);
 			}
 		} else {

--- a/src/session.c
+++ b/src/session.c
@@ -204,7 +204,7 @@ static WMPropList *makeWindowState(WWindow *wwin, WApplication *wapp)
 		miniaturized = wwin->flags.miniaturized ? sYes : sNo;
 		hidden = wwin->flags.hidden ? sYes : sNo;
 		snprintf(buffer, sizeof(buffer), "%ix%i+%i+%i",
-			 wwin->client.width, wwin->client.height, wwin->frame_x, wwin->frame_y);
+			 wwin->width, wwin->height, wwin->frame_x, wwin->frame_y);
 
 		geometry = WMCreatePLString(buffer);
 		for (mask = 0, i = 0; i < MAX_WINDOW_SHORTCUTS; i++) {

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -167,8 +167,8 @@ void switchmenu_additem(WMenu *menu, virtual_screen *vscr, WWindow *wwin)
 	    IS_GNUSTEP_MENU(wwin))
 		return;
 
-	if (wwin->frame->title)
-		snprintf(title, len, "%s", wwin->frame->title);
+	if (wwin->title)
+		snprintf(title, len, "%s", wwin->title);
 	else
 		snprintf(title, len, "%s", DEF_WINDOW_TITLE);
 
@@ -236,8 +236,8 @@ static void switchmenu_changeitem(virtual_screen *vscr, WWindow *wwin)
 			if (entry->text)
 				wfree(entry->text);
 
-			if (wwin->frame->title)
-				snprintf(title, MAX_MENU_TEXT_LENGTH, "%s", wwin->frame->title);
+			if (wwin->title)
+				snprintf(title, MAX_MENU_TEXT_LENGTH, "%s", wwin->title);
 			else
 				snprintf(title, MAX_MENU_TEXT_LENGTH, "%s", DEF_WINDOW_TITLE);
 

--- a/src/switchpanel.c
+++ b/src/switchpanel.c
@@ -633,7 +633,7 @@ WWindow *wSwitchPanelSelectNext(WSwitchPanel *panel, int back, int ignore_minimi
 		scrollIcons(panel, panel->current - panel->firstVisible - panel->visibleCount + 1);
 
 	if (panel->win) {
-		drawTitle(panel, panel->current, wwin->frame->title);
+		drawTitle(panel, panel->current, wwin->title);
 		if (panel->current != orig)
 			changeImage(panel, orig, 0, dim, False);
 		changeImage(panel, panel->current, 1, False, False);
@@ -661,7 +661,7 @@ WWindow *wSwitchPanelSelectFirst(WSwitchPanel *panel, int back)
 	}
 
 	wwin = WMGetFromArray(panel->windows, panel->current);
-	title = wwin->frame->title;
+	title = wwin->title;
 
 	if (panel->win) {
 		for (WMArrayFirst(panel->windows, &(i)); (i) != WANotFound; WMArrayNext(panel->windows, &(i)))
@@ -701,7 +701,7 @@ WWindow *wSwitchPanelHandleEvent(WSwitchPanel *panel, XEvent *event)
 
 		wwin = WMGetFromArray(panel->windows, focus);
 
-		drawTitle(panel, panel->current, wwin->frame->title);
+		drawTitle(panel, panel->current, wwin->title);
 
 		return wwin;
 	}

--- a/src/usermenu.c
+++ b/src/usermenu.c
@@ -264,7 +264,7 @@ static WMenu *configureUserMenu(virtual_screen *vscr, WMPropList *plum)
 
 			submenu = configureUserMenu(vscr, elem);
 			if (submenu)
-				mentry = wMenuAddCallback(menu, submenu->frame->title, NULL, NULL);
+				mentry = wMenuAddCallback(menu, submenu->title, NULL, NULL);
 
 			wMenuEntrySetCascade_create(menu, mentry, submenu);
 		} else {

--- a/src/window.c
+++ b/src/window.c
@@ -1390,7 +1390,7 @@ WWindow *wManageWindow(virtual_screen *vscr, Window window)
 	if (HAS_BORDER(wwin))
 		flags |= WFF_BORDER;
 
-	wwin->frame = wframewindow_create(width, height, flags);
+	wwin->frame = wframewindow_create(wwin, NULL, width, height, flags);
 	wframewindow_map(wwin->frame, vscr, window_level, x, y,
 		      &wPreferences.window_title_clearance,
 		      &wPreferences.window_title_min_height,
@@ -1541,7 +1541,7 @@ WWindow *wManageInternalWindow(virtual_screen *vscr, Window window, Window owner
 	foo |= WFF_LANGUAGE_BUTTON;
 #endif
 
-	wwin->frame = wframewindow_create(width, height, foo);
+	wwin->frame = wframewindow_create(wwin, NULL, width, height, foo);
 	wframewindow_map(wwin->frame, vscr, WMFloatingLevel,
 			 wwin->frame_x, wwin->frame_y,
 			 &wPreferences.window_title_clearance,

--- a/src/window.c
+++ b/src/window.c
@@ -145,7 +145,7 @@ static void appearanceObserver(void *self, WMNotification *notif)
 		wWindowConfigureBorders(wwin);
 		if (wwin->flags.shaded) {
 			wFrameWindowResize(wwin->frame, wwin->frame->core->width, wwin->frame->top_width - 1);
-			wwin->client.y = wwin->frame_y - wwin->client.height + wwin->frame->top_width;
+			wwin->client.y = wwin->frame_y - wwin->height + wwin->frame->top_width;
 			wWindowSynthConfigureNotify(wwin);
 		}
 	}
@@ -1530,8 +1530,8 @@ WWindow *wManageInternalWindow(virtual_screen *vscr, Window window, Window owner
 	wwin->transient_for = owner;
 	wwin->client.x = x;
 	wwin->client.y = y;
-	wwin->client.width = width;
-	wwin->client.height = height;
+	wwin->width = width;
+	wwin->height = height;
 	wwin->frame_x = wwin->client.x;
 	wwin->frame_y = wwin->client.y;
 
@@ -1580,7 +1580,7 @@ WWindow *wManageInternalWindow(virtual_screen *vscr, Window window, Window owner
 	wwin->client.y += wwin->frame->top_width;
 
 	XReparentWindow(dpy, wwin->client_win, wwin->frame->core->window, 0, wwin->frame->top_width);
-	wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, wwin->client.width, wwin->client.height);
+	wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, wwin->width, wwin->height);
 
 	wwindow_set_frame_descriptor(wwin);
 
@@ -1813,7 +1813,7 @@ void wWindowSingleFocus(WWindow *wwin)
 	move = wScreenBringInside(wwin->vscr, &x, &y, wwin->frame->core->width, wwin->frame->core->height);
 
 	if (move)
-		wWindowConfigure(wwin, x, y, wwin->client.width, wwin->client.height);
+		wWindowConfigure(wwin, x, y, wwin->width, wwin->height);
 }
 
 void wWindowFocusPrev(WWindow *wwin, Bool inSameWorkspace)
@@ -2165,8 +2165,8 @@ void wWindowSynthConfigureNotify(WWindow *wwin)
 
 	sevent.xconfigure.x = wwin->client.x;
 	sevent.xconfigure.y = wwin->client.y;
-	sevent.xconfigure.width = wwin->client.width;
-	sevent.xconfigure.height = wwin->client.height;
+	sevent.xconfigure.width = wwin->width;
+	sevent.xconfigure.height = wwin->height;
 
 	sevent.xconfigure.border_width = wwin->old_border_width;
 	if (HAS_TITLEBAR(wwin) && wwin->frame->titlebar)
@@ -2207,7 +2207,7 @@ void wWindowConfigure(WWindow *wwin, int req_x, int req_y, int req_width, int re
 	int synth_notify = False;
 	int resize;
 
-	resize = (req_width != wwin->client.width || req_height != wwin->client.height);
+	resize = (req_width != wwin->width || req_height != wwin->height);
 	/*
 	 * if the window is being moved but not resized then
 	 * send a synthetic ConfigureNotify
@@ -2247,8 +2247,8 @@ void wWindowConfigure(WWindow *wwin, int req_x, int req_y, int req_width, int re
 
 		wwin->client.x = req_x;
 		wwin->client.y = req_y + wwin->frame->top_width;
-		wwin->client.width = req_width;
-		wwin->client.height = req_height;
+		wwin->width = req_width;
+		wwin->height = req_height;
 	} else {
 		wwin->client.x = req_x;
 		wwin->client.y = req_y + wwin->frame->top_width;
@@ -2456,7 +2456,7 @@ void wWindowConfigureBorders(WWindow *wwin)
 		newy = wwin->frame_y + oldh - wwin->frame->top_width;
 
 		XMoveWindow(dpy, wwin->client_win, 0, wwin->frame->top_width);
-		wWindowConfigure(wwin, wwin->frame_x, newy, wwin->client.width, wwin->client.height);
+		wWindowConfigure(wwin, wwin->frame_x, newy, wwin->width, wwin->height);
 	}
 
 #ifdef USE_XSHAPE
@@ -3002,15 +3002,15 @@ static void frameMouseDown(WObjDescriptor *desc, XEvent *event)
 
 	if (event->xbutton.state & ControlMask) {
 		if (event->xbutton.button == Button4) {
-			new_width = wwin->client.width - resize_width_increment;
-			wWindowConstrainSize(wwin, &new_width, &wwin->client.height);
-			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, new_width, wwin->client.height);
+			new_width = wwin->width - resize_width_increment;
+			wWindowConstrainSize(wwin, &new_width, &wwin->height);
+			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, new_width, wwin->height);
 		}
 
 		if (event->xbutton.button == Button5) {
-			new_width = wwin->client.width + resize_width_increment;
-			wWindowConstrainSize(wwin, &new_width, &wwin->client.height);
-			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, new_width, wwin->client.height);
+			new_width = wwin->width + resize_width_increment;
+			wWindowConstrainSize(wwin, &new_width, &wwin->height);
+			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, new_width, wwin->height);
 		}
 	}
 
@@ -3024,13 +3024,13 @@ static void frameMouseDown(WObjDescriptor *desc, XEvent *event)
 		if (event->xbutton.button == Button3) {
 			wMouseResizeWindow(wwin, event);
 		} else if (event->xbutton.button == Button4) {
-			new_height = wwin->client.height - resize_height_increment;
-			wWindowConstrainSize(wwin, &wwin->client.width, &new_height);
-			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, wwin->client.width, new_height);
+			new_height = wwin->height - resize_height_increment;
+			wWindowConstrainSize(wwin, &wwin->width, &new_height);
+			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, wwin->width, new_height);
 		} else if (event->xbutton.button == Button5) {
-			new_height = wwin->client.height + resize_height_increment;
-			wWindowConstrainSize(wwin, &wwin->client.width, &new_height);
-			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, wwin->client.width, new_height);
+			new_height = wwin->height + resize_height_increment;
+			wWindowConstrainSize(wwin, &wwin->width, &new_height);
+			wWindowConfigure(wwin, wwin->frame_x, wwin->frame_y, wwin->width, new_height);
 		} else if (event->xbutton.button == Button1 || event->xbutton.button == Button2) {
 			wMouseMoveWindow(wwin, event);
 		}

--- a/src/window.c
+++ b/src/window.c
@@ -1095,6 +1095,31 @@ static void wwindow_update_title(Display *dpy, Window window, WWindow *wwin)
 		XFree(title);
 }
 
+void wWindowUpdateName(WWindow *wwin, const char *newTitle)
+{
+	const char *title;
+
+	if (!newTitle)
+		title = DEF_WINDOW_TITLE; /* the hint was removed */
+	else
+		title = newTitle;
+
+	/* check if the title is the same as before */
+	if ((wwin->title) && (!strcmp(wwin->title, title)))
+		return;
+
+	if (wwin->title)
+		wfree(wwin->title);
+
+	wwin->title = wstrdup(title);
+
+	if (!wwin->frame)
+		return;
+
+	if (wFrameWindowChangeTitle(wwin->frame, title))
+		WMPostNotificationName(WMNChangedName, wwin, NULL);
+}
+
 /*
  *----------------------------------------------------------------
  * wManageWindow--
@@ -1907,31 +1932,6 @@ void wWindowUnfocus(WWindow *wwin)
 	wwin->flags.focused = 0;
 	wWindowResetMouseGrabs(wwin);
 	WMPostNotificationName(WMNChangedFocus, wwin, (void *)False);
-}
-
-void wWindowUpdateName(WWindow *wwin, const char *newTitle)
-{
-	const char *title;
-
-	if (!newTitle)
-		title = DEF_WINDOW_TITLE; /* the hint was removed */
-	else
-		title = newTitle;
-
-	/* check if the title is the same as before */
-	if ((wwin->title) && (!strcmp(wwin->title, title)))
-		return;
-
-	if (wwin->title)
-		wfree(wwin->title);
-
-	wwin->title = wstrdup(title);
-
-	if (!wwin->frame)
-		return;
-
-	if (wFrameWindowChangeTitle(wwin->frame, title))
-		WMPostNotificationName(WMNChangedName, wwin, NULL);
 }
 
 /*

--- a/src/window.h
+++ b/src/window.h
@@ -177,6 +177,9 @@ typedef struct WWindow {
 	struct WWindow *prev;			/* window focus list */
 	struct WWindow *next;
 
+	unsigned int width;			/* current width */
+	unsigned int height;			/* current heiht */
+
 	virtual_screen *vscr; 			/* pointer to the screen structure */
 	WWindowAttributes user_flags;		/* window attribute flags set by user */
 	WWindowAttributes defined_user_flags;	/* mask for user_flags */
@@ -208,7 +211,6 @@ typedef struct WWindow {
 	struct {
 		int x, y;			/* position of *client* relative
 						 * to root */
-		unsigned int width, height;	/* size of the client window */
 	} client;
 
 	XSizeHints *normal_hints;		/* WM_NORMAL_HINTS */

--- a/src/wmspec.c
+++ b/src/wmspec.c
@@ -74,8 +74,8 @@ static Atom net_wm_moveresize;	/* TODO */
 /* Application Window Properties */
 static Atom net_wm_name;
 static Atom net_wm_visible_name;	/* TODO (unnecessary?) */
-static Atom net_wm_icon_name;
-static Atom net_wm_visible_icon_name;	/* TODO (unnecessary?) */
+static Atom net_wm_title;
+static Atom net_wm_visible_title;	/* TODO (unnecessary?) */
 static Atom net_wm_desktop;
 static Atom net_wm_window_type;
 static Atom net_wm_window_type_desktop;
@@ -157,8 +157,8 @@ static atomitem_t atomNames[] = {
 
 	{"_NET_WM_NAME", &net_wm_name},
 	{"_NET_WM_VISIBLE_NAME", &net_wm_visible_name},
-	{"_NET_WM_ICON_NAME", &net_wm_icon_name},
-	{"_NET_WM_VISIBLE_ICON_NAME", &net_wm_visible_icon_name},
+	{"_NET_WM_ICON_NAME", &net_wm_title},
+	{"_NET_WM_VISIBLE_ICON_NAME", &net_wm_visible_title},
 	{"_NET_WM_DESKTOP", &net_wm_desktop},
 	{"_NET_WM_WINDOW_TYPE", &net_wm_window_type},
 	{"_NET_WM_WINDOW_TYPE_DESKTOP", &net_wm_window_type_desktop},
@@ -335,7 +335,7 @@ static void setSupportedHints(WScreen *scr)
 	atom[i++] = net_frame_extents;
 
 	atom[i++] = net_wm_name;
-	atom[i++] = net_wm_icon_name;
+	atom[i++] = net_wm_title;
 
 	XChangeProperty(dpy, scr->root_win, net_supported, XA_ATOM, 32, PropModeReplace, (unsigned char *)atom, i);
 
@@ -1695,7 +1695,7 @@ void wNETWMCheckClientHintChange(WWindow *wwin, XPropertyEvent *event)
 		wWindowUpdateName(wwin, name);
 		if (name)
 			wfree(name);
-	} else if (event->atom == net_wm_icon_name) {
+	} else if (event->atom == net_wm_title) {
 		if (wwin->icon) {
 			wIconChangeTitle(wwin->icon, wwin);
 			wIconPaint(wwin->icon);
@@ -1750,7 +1750,7 @@ char *wNETWMGetIconName(Window window)
 	char *ret;
 	int size;
 
-	name = (char *)PropGetCheckProperty(window, net_wm_icon_name, utf8_string, 0, 0, &size);
+	name = (char *)PropGetCheckProperty(window, net_wm_title, utf8_string, 0, 0, &size);
 	if (name) {
 		ret = wstrndup(name, size);
 		XFree(name);


### PR DESCRIPTION
These patches removes the framewin title variable. I want to have the variables only in one place, not in multiple lines in the code, because is difficult to maintain.