### PR TITLE
Create and destroy rootmenu and switchmenu

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -2113,6 +2113,12 @@ static void menuCloseClick(WCoreWindow *sender, void *data, XEvent *event)
 	(void) sender;
 	(void) event;
 
+	/* If we click on the switchmenu close button, we destroy it */
+	if (menu == menu->vscr->menu.switch_menu) {
+		switchmenu_destroy(menu->vscr);
+		return;
+	}
+
 	wMenuUnmap(menu);
 }
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -2119,6 +2119,12 @@ static void menuCloseClick(WCoreWindow *sender, void *data, XEvent *event)
 		return;
 	}
 
+	/* If we click on the rootmenu close button, we destroy it */
+	if (menu == menu->vscr->menu.root_menu) {
+		rootmenu_destroy(menu->vscr);
+		return;
+	}
+
 	wMenuUnmap(menu);
 }
 

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1469,6 +1469,8 @@ static WMenu *makeDefaultMenu(virtual_screen *vscr)
 	wMenuAddCallback(menu, _("Restart"), restartCommand, NULL);
 	wMenuAddCallback(menu, _("Exit..."), exitCommand, NULL);
 
+	menu_map(menu, vscr);
+
 	return menu;
 }
 
@@ -1689,7 +1691,6 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 		/* menu hasn't changed or could not be read */
 		if (!vscr->menu.root_menu) {
 			menu = makeDefaultMenu(vscr);
-			menu_map(menu, vscr);
 			vscr->menu.root_menu = menu;
 		}
 		menu = vscr->menu.root_menu;

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -829,8 +829,8 @@ static WMenuEntry *addWorkspaceMenu(virtual_screen *vscr, WMenu *menu, const cha
 
 static void cleanupWindowsMenu(WMenu *menu)
 {
-	if (menu->frame->vscr->menu.switch_menu == menu)
-		menu->frame->vscr->menu.switch_menu = NULL;
+	if (menu->frame->vscr->menu.root_switch == menu)
+		menu->frame->vscr->menu.root_switch = NULL;
 }
 
 static WMenuEntry *addWindowsMenu(virtual_screen *vscr, WMenu *menu, const char *title)
@@ -851,11 +851,11 @@ static WMenuEntry *addWindowsMenu(virtual_screen *vscr, WMenu *menu, const char 
 	menu_map(wwmenu, vscr);
 
 	wwmenu->on_destroy = cleanupWindowsMenu;
-	vscr->menu.switch_menu = wwmenu;
+	vscr->menu.root_switch = wwmenu;
 	wwin = vscr->window.focused;
 	while (wwin) {
-		switchmenu_additem(vscr->menu.switch_menu, wwin);
-		menu_move_visible(vscr->menu.switch_menu);
+		switchmenu_additem(vscr->menu.root_switch, wwin);
+		menu_move_visible(vscr->menu.root_switch);
 		wwin = wwin->prev;
 	}
 

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1457,6 +1457,11 @@ static WMenu *makeDefaultMenu(virtual_screen *vscr)
 {
 	WMenu *menu = NULL;
 
+	wMessageDialog(vscr, _("Error"),
+		       _("The applications menu could not be loaded. "
+			 "Look at the console output for a detailed "
+			 "description of the errors."), _("OK"), NULL, NULL);
+
 	menu = menu_create(vscr, _("Commands"));
 
 	wMenuAddCallback(menu, M_("XTerm"), execCommand, "xterm");
@@ -1683,11 +1688,6 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 	if (!menu) {
 		/* menu hasn't changed or could not be read */
 		if (!vscr->menu.root_menu) {
-			wMessageDialog(vscr, _("Error"),
-				       _("The applications menu could not be loaded. "
-					 "Look at the console output for a detailed "
-					 "description of the errors."), _("OK"), NULL, NULL);
-
 			menu = makeDefaultMenu(vscr);
 			menu_map(menu, vscr);
 			vscr->menu.root_menu = menu;

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1648,6 +1648,18 @@ static WMenu *create_rootmenu(virtual_screen *vscr)
 	return menu;
 }
 
+void rootmenu_destroy(virtual_screen *vscr)
+{
+	if (!vscr->menu.root_menu)
+		return;
+
+	wMenuDestroy(vscr->menu.root_menu, True);
+	vscr->menu.root_menu = NULL;
+	vscr->menu.flags.root_menu_changed_shortcuts = 0;
+	vscr->menu.flags.added_workspace_menu = 0;
+	vscr->menu.flags.added_window_menu = 0;
+}
+
 /*
  *----------------------------------------------------------------------
  * OpenRootMenu--

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1687,7 +1687,7 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 
 	if (rootmenu->flags.mapped) {
 		if (!rootmenu->flags.buttoned) {
-			wMenuUnmap(rootmenu);
+			switchmenu_destroy(vscr);
 		} else {
 			wRaiseFrame(rootmenu->frame->core);
 

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1625,10 +1625,14 @@ static WMenu *configureMenu(virtual_screen *vscr, WMPropList *definition)
 	return menu;
 }
 
-static WMenu *create_menu_from_dictionary(virtual_screen *vscr)
+static WMenu *create_rootmenu(virtual_screen *vscr)
 {
 	WMenu *menu = NULL;
 	WMPropList *definition;
+
+	vscr->menu.flags.root_menu_changed_shortcuts = 0;
+	vscr->menu.flags.added_workspace_menu = 0;
+	vscr->menu.flags.added_window_menu = 0;
 
 	definition = w_global.domain.root_menu->dictionary;
 	if (!definition)
@@ -1638,6 +1642,8 @@ static WMenu *create_menu_from_dictionary(virtual_screen *vscr)
 		return NULL;
 
 	menu = configureMenu(vscr, definition);
+	if (!menu)
+		menu = makeDefaultMenu(vscr);
 
 	return menu;
 }
@@ -1662,10 +1668,6 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 {
 	WMenu *menu = NULL;
 
-	vscr->menu.flags.root_menu_changed_shortcuts = 0;
-	vscr->menu.flags.added_workspace_menu = 0;
-	vscr->menu.flags.added_window_menu = 0;
-
 	if (vscr->menu.root_menu && vscr->menu.root_menu->flags.mapped) {
 		menu = vscr->menu.root_menu;
 		if (!menu->flags.buttoned) {
@@ -1679,12 +1681,8 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 		return;
 	}
 
-	menu = create_menu_from_dictionary(vscr);
-	if (!menu)
-		menu = makeDefaultMenu(vscr);
-
-	vscr->menu.root_menu = menu;
-	rootmenu_map(menu, x, y, keyboard);
+	vscr->menu.root_menu = create_rootmenu(vscr);
+	rootmenu_map(vscr->menu.root_menu, x, y, keyboard);
 
 	if (vscr->menu.flags.root_menu_changed_shortcuts)
 		rebindKeygrabs(vscr);

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1634,16 +1634,10 @@ static WMenu *create_menu_from_dictionary(virtual_screen *vscr)
 	if (!definition)
 		return NULL;
 
-	if (WMIsPLArray(definition)) {
-		if (!vscr->menu.root_menu ||
-		    w_global.domain.root_menu->timestamp > vscr->menu.root_menu->timestamp) {
-			menu = configureMenu(vscr, definition);
-			if (menu)
-				menu->timestamp = w_global.domain.root_menu->timestamp;
-		}
-	} else {
-		menu = configureMenu(vscr, definition);
-	}
+	if (!WMIsPLArray(definition))
+		return NULL;
+
+	menu = configureMenu(vscr, definition);
 
 	return menu;
 }
@@ -1686,22 +1680,10 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 	}
 
 	menu = create_menu_from_dictionary(vscr);
+	if (!menu)
+		menu = makeDefaultMenu(vscr);
 
-	if (!menu) {
-		/* menu hasn't changed or could not be read */
-		if (!vscr->menu.root_menu) {
-			menu = makeDefaultMenu(vscr);
-			vscr->menu.root_menu = menu;
-		}
-		menu = vscr->menu.root_menu;
-	} else {
-		/* new root menu */
-		if (vscr->menu.root_menu)
-			wMenuDestroy(vscr->menu.root_menu, True);
-
-		vscr->menu.root_menu = menu;
-	}
-
+	vscr->menu.root_menu = menu;
 	rootmenu_map(menu, x, y, keyboard);
 
 	if (vscr->menu.flags.root_menu_changed_shortcuts)

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1666,22 +1666,25 @@ static WMenu *create_rootmenu(virtual_screen *vscr)
  */
 void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 {
-	WMenu *menu = NULL;
+	WMenu *rootmenu = NULL;
 
-	if (vscr->menu.root_menu && vscr->menu.root_menu->flags.mapped) {
-		menu = vscr->menu.root_menu;
-		if (!menu->flags.buttoned) {
-			wMenuUnmap(menu);
+	if (!vscr->menu.root_menu)
+		vscr->menu.root_menu = create_rootmenu(vscr);
+
+	rootmenu = vscr->menu.root_menu;
+
+	if (rootmenu->flags.mapped) {
+		if (!rootmenu->flags.buttoned) {
+			wMenuUnmap(rootmenu);
 		} else {
-			wRaiseFrame(menu->frame->core);
+			wRaiseFrame(rootmenu->frame->core);
 
 			if (keyboard)
-				wMenuMapAt(vscr, menu, 0, 0, True);
+				wMenuMapAt(vscr, rootmenu, 0, 0, True);
 		}
 		return;
 	}
 
-	vscr->menu.root_menu = create_rootmenu(vscr);
 	rootmenu_map(vscr->menu.root_menu, x, y, keyboard);
 
 	if (vscr->menu.flags.root_menu_changed_shortcuts)

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -70,6 +70,7 @@ static WMenu *readMenuFile(virtual_screen *vscr, const char *file_name);
 static WMenu *readMenuDirectory(virtual_screen *vscr, const char *title, char **file_name, const char *command);
 static WMenu *configureMenu(virtual_screen *vscr, WMPropList *definition);
 static void menu_parser_register_macros(WMenuParser parser);
+static void rootmenu_map(WMenu *menu, int x, int y, int keyboard);
 
 typedef struct Shortcut {
 	struct Shortcut *next;
@@ -1691,22 +1692,33 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 		vscr->menu.root_menu = menu;
 	}
 
-	if (menu) {
-		int newx, newy;
-
-		if (keyboard && x == 0 && y == 0) {
-			newx = newy = 0;
-		} else if (keyboard && x == vscr->screen_ptr->scr_width / 2 && y == vscr->screen_ptr->scr_height / 2) {
-			newx = x - menu->frame->core->width / 2;
-			newy = y - menu->frame->core->height / 2;
-		} else {
-			newx = x - menu->frame->core->width / 2;
-			newy = y;
-		}
-
-		wMenuMapAt(vscr, menu, newx, newy, keyboard);
-	}
+	rootmenu_map(menu, x, y, keyboard);
 
 	if (vscr->menu.flags.root_menu_changed_shortcuts)
 		rebindKeygrabs(vscr);
+}
+
+static void rootmenu_map(WMenu *menu, int x, int y, int keyboard)
+{
+	virtual_screen *vscr;
+	int newx, newy;
+
+	if (!menu)
+		return;
+
+	vscr = menu->vscr;
+
+	if (keyboard && x == 0 && y == 0) {
+		newx = newy = 0;
+	} else if (keyboard &&
+		   x == vscr->screen_ptr->scr_width / 2 &&
+		   y == vscr->screen_ptr->scr_height / 2) {
+		newx = x - menu->frame->core->width / 2;
+		newy = y - menu->frame->core->height / 2;
+	} else {
+		newx = x - menu->frame->core->width / 2;
+		newy = y;
+	}
+
+	wMenuMapAt(vscr, menu, newx, newy, keyboard);
 }

--- a/src/rootmenu.c
+++ b/src/rootmenu.c
@@ -1618,6 +1618,29 @@ static WMenu *configureMenu(virtual_screen *vscr, WMPropList *definition)
 	return menu;
 }
 
+static WMenu *create_menu_from_dictionary(virtual_screen *vscr)
+{
+	WMenu *menu = NULL;
+	WMPropList *definition;
+
+	definition = w_global.domain.root_menu->dictionary;
+	if (!definition)
+		return NULL;
+
+	if (WMIsPLArray(definition)) {
+		if (!vscr->menu.root_menu ||
+		    w_global.domain.root_menu->timestamp > vscr->menu.root_menu->timestamp) {
+			menu = configureMenu(vscr, definition);
+			if (menu)
+				menu->timestamp = w_global.domain.root_menu->timestamp;
+		}
+	} else {
+		menu = configureMenu(vscr, definition);
+	}
+
+	return menu;
+}
+
 /*
  *----------------------------------------------------------------------
  * OpenRootMenu--
@@ -1637,7 +1660,6 @@ static WMenu *configureMenu(virtual_screen *vscr, WMPropList *definition)
 void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 {
 	WMenu *menu = NULL;
-	WMPropList *definition;
 
 	vscr->menu.flags.root_menu_changed_shortcuts = 0;
 	vscr->menu.flags.added_workspace_menu = 0;
@@ -1656,20 +1678,7 @@ void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard)
 		return;
 	}
 
-	definition = w_global.domain.root_menu->dictionary;
-
-	if (definition) {
-		if (WMIsPLArray(definition)) {
-			if (!vscr->menu.root_menu ||
-			    w_global.domain.root_menu->timestamp > vscr->menu.root_menu->timestamp) {
-				menu = configureMenu(vscr, definition);
-				if (menu)
-					menu->timestamp = w_global.domain.root_menu->timestamp;
-			}
-		} else {
-			menu = configureMenu(vscr, definition);
-		}
-	}
+	menu = create_menu_from_dictionary(vscr);
 
 	if (!menu) {
 		/* menu hasn't changed or could not be read */

--- a/src/rootmenu.h
+++ b/src/rootmenu.h
@@ -25,5 +25,6 @@
 Bool wRootMenuPerformShortcut(XEvent *event);
 void wRootMenuBindShortcuts(Window window);
 void OpenRootMenu(virtual_screen *vscr, int x, int y, int keyboard);
+void rootmenu_destroy(virtual_screen *vscr);
 
 #endif /* WMROOTMENU_H */

--- a/src/screen.c
+++ b/src/screen.c
@@ -892,8 +892,6 @@ void virtual_screen_restore_map(virtual_screen *vscr)
 {
 	WMPropList *state, *dDock;
 
-	vscr->menu.switch_menu = switchmenu_create(vscr);
-	vscr->menu.root_switch = switchmenu_create(vscr);
 	window_menu_create(vscr);
 
 	if (!wPreferences.flags.nodock) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -893,6 +893,7 @@ void virtual_screen_restore_map(virtual_screen *vscr)
 	WMPropList *state, *dDock;
 
 	vscr->menu.switch_menu = switchmenu_create(vscr);
+	vscr->menu.root_switch = switchmenu_create(vscr);
 	window_menu_create(vscr);
 
 	if (!wPreferences.flags.nodock) {

--- a/src/screen.h
+++ b/src/screen.h
@@ -60,6 +60,7 @@ struct virtual_screen {
 	/* Menu related */
 	struct {
 		struct WMenu *root_menu;   /* root window menu */
+		struct WMenu *root_switch; /* window list menu for root_menu */
 		struct WMenu *switch_menu; /* window list menu */
 		struct WMenu *icon_menu;   /* icon/appicon menu */
 		struct WMenu *window_menu; /* window command menu */

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -345,14 +345,16 @@ static void switchmenu_changestate(WMenu *menu, WWindow *wwin)
 	}
 }
 
-static void UpdateSwitchMenuWorkspace(virtual_screen *vscr, int workspace)
+static void update_menu_workspacerename(WMenu *menu, int workspace)
 {
-	WMenu *menu = vscr->menu.switch_menu;
-	int i;
+	virtual_screen *vscr;
 	WWindow *wwin;
+	int i;
 
 	if (!menu)
 		return;
+
+	vscr = menu->vscr;
 
 	for (i = 0; i < menu->entry_no; i++) {
 		wwin = (WWindow *) menu->entries[i]->clientdata;
@@ -413,10 +415,11 @@ static void wsobserver(void *self, WMNotification *notif)
 	virtual_screen *vscr = (virtual_screen *) WMGetNotificationObject(notif);
 	const char *name = WMGetNotificationName(notif);
 	void *data = WMGetNotificationClientData(notif);
+	int workspace = (uintptr_t) data;
 
 	/* Parameter not used, but tell the compiler that it is ok */
 	(void) self;
 
 	if (strcmp(name, WMNWorkspaceNameChanged) == 0)
-		UpdateSwitchMenuWorkspace(vscr, (uintptr_t) data);
+		update_menu_workspacerename(vscr->menu.switch_menu, workspace);
 }

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -312,16 +312,16 @@ static void switchmenu_changeworkspaceitem(WMenu *menu, WWindow *wwin)
 }
 
 /* Update switch menu */
-static void switchmenu_changestate(virtual_screen *vscr, WWindow *wwin)
+static void switchmenu_changestate(WMenu *menu, WWindow *wwin)
 {
 	WMenuEntry *entry;
 	int i;
 
-	if (!vscr->menu.switch_menu)
+	if (!menu)
 		return;
 
-	for (i = 0; i < vscr->menu.switch_menu->entry_no; i++) {
-		entry = vscr->menu.switch_menu->entries[i];
+	for (i = 0; i < menu->entry_no; i++) {
+		entry = menu->entries[i];
 		/* this is the entry that was changed */
 		if (entry->clientdata == wwin) {
 			if (wwin->flags.hidden) {
@@ -387,14 +387,14 @@ static void observer(void *self, WMNotification * notif)
 	} else if (strcmp(name, WMNChangedWorkspace) == 0) {
 		switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedFocus) == 0) {
-		switchmenu_changestate(wwin->vscr, wwin);
+		switchmenu_changestate(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedName) == 0) {
 		switchmenu_changeitem(wwin->vscr, wwin);
 	} else if (strcmp(name, WMNChangedState) == 0) {
 		if (strcmp((char *)data, "omnipresent") == 0)
 			switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);
 		else
-			switchmenu_changestate(wwin->vscr, wwin);
+			switchmenu_changestate(wwin->vscr->menu.switch_menu, wwin);
 	}
 
 	/* If menu is not mapped, exit */

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -226,17 +226,20 @@ void switchmenu_delitem(WMenu *menu, WWindow *wwin)
 	}
 }
 
-static void switchmenu_changeitem(virtual_screen *vscr, WWindow *wwin)
+static void switchmenu_changeitem(WMenu *menu, WWindow *wwin)
 {
+	virtual_screen *vscr;
 	WMenuEntry *entry;
 	char title[MAX_MENU_TEXT_LENGTH + 6];
 	int i;
 
-	if (!vscr->menu.switch_menu)
+	if (!menu)
 		return;
 
-	for (i = 0; i < vscr->menu.switch_menu->entry_no; i++) {
-		entry = vscr->menu.switch_menu->entries[i];
+	vscr = menu->vscr;
+
+	for (i = 0; i < menu->entry_no; i++) {
+		entry = menu->entries[i];
 		/* this is the entry that was changed */
 		if (entry->clientdata == wwin) {
 			if (entry->text)
@@ -389,7 +392,7 @@ static void observer(void *self, WMNotification * notif)
 	} else if (strcmp(name, WMNChangedFocus) == 0) {
 		switchmenu_changestate(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedName) == 0) {
-		switchmenu_changeitem(wwin->vscr, wwin);
+		switchmenu_changeitem(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedState) == 0) {
 		if (strcmp((char *)data, "omnipresent") == 0)
 			switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -102,6 +102,7 @@ WMenu *switchmenu_create(virtual_screen *vscr)
 		wwin = wwin->prev;
 	}
 
+	menu_move_visible(switch_menu);
 	return switch_menu;
 }
 

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -129,7 +129,7 @@ void OpenSwitchMenu(virtual_screen *vscr, int x, int y, int keyboard)
 	/* Mapped, so unmap or raise */
 	if (switchmenu->flags.mapped) {
 		if (!switchmenu->flags.buttoned) {
-			wMenuUnmap(switchmenu);
+			switchmenu_destroy(vscr);
 		} else {
 			wRaiseFrame(switchmenu->frame->core);
 

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -254,13 +254,16 @@ static void switchmenu_changeitem(virtual_screen *vscr, WWindow *wwin)
 	}
 }
 
-static void switchmenu_changeworkspaceitem(WMenu *menu, virtual_screen *vscr, WWindow *wwin)
+static void switchmenu_changeworkspaceitem(WMenu *menu, WWindow *wwin)
 {
+	virtual_screen *vscr;
 	WMenuEntry *entry;
 	int i;
 
 	if (!menu)
 		return;
+
+	vscr = menu->vscr;
 
 	for (i = 0; i < menu->entry_no; i++) {
 		entry = menu->entries[i];
@@ -375,14 +378,14 @@ static void observer(void *self, WMNotification * notif)
 	} else if (strcmp(name, WMNUnmanaged) == 0) {
 		switchmenu_delitem(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedWorkspace) == 0) {
-		switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin->vscr, wwin);
+		switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedFocus) == 0) {
 		switchmenu_changestate(wwin->vscr, wwin);
 	} else if (strcmp(name, WMNChangedName) == 0) {
 		switchmenu_changeitem(wwin->vscr, wwin);
 	} else if (strcmp(name, WMNChangedState) == 0) {
 		if (strcmp((char *)data, "omnipresent") == 0)
-			switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin->vscr, wwin);
+			switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);
 		else
 			switchmenu_changestate(wwin->vscr, wwin);
 	}

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -119,7 +119,12 @@ void switchmenu_destroy(virtual_screen *vscr)
 /* Open switch menu */
 void OpenSwitchMenu(virtual_screen *vscr, int x, int y, int keyboard)
 {
-	WMenu *switchmenu = vscr->menu.switch_menu;
+	WMenu *switchmenu;
+
+	if (!vscr->menu.switch_menu)
+		vscr->menu.switch_menu = switchmenu_create(vscr);
+
+	switchmenu = vscr->menu.switch_menu;
 
 	/* Mapped, so unmap or raise */
 	if (switchmenu->flags.mapped) {

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -414,7 +414,8 @@ static void observer(void *self, WMNotification * notif)
 	}
 
 	/* If menu is not mapped, exit */
-	if (!wwin->vscr->menu.switch_menu->frame ||
+	if (!wwin->vscr->menu.switch_menu ||
+	    !wwin->vscr->menu.switch_menu->frame ||
 	    !wwin->vscr->menu.switch_menu->frame->vscr)
 		return;
 

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -389,7 +389,7 @@ static void update_menu_workspacerename(WMenu *menu, int workspace)
 		wMenuRealize(menu);
 }
 
-static void observer(void *self, WMNotification * notif)
+static void observer(void *self, WMNotification *notif)
 {
 	WWindow *wwin = (WWindow *) WMGetNotificationObject(notif);
 	const char *name = WMGetNotificationName(notif);
@@ -403,19 +403,27 @@ static void observer(void *self, WMNotification * notif)
 
 	if (strcmp(name, WMNManaged) == 0) {
 		switchmenu_additem(wwin->vscr->menu.switch_menu, wwin);
+		switchmenu_additem(wwin->vscr->menu.root_switch, wwin);
 	} else if (strcmp(name, WMNUnmanaged) == 0) {
 		switchmenu_delitem(wwin->vscr->menu.switch_menu, wwin);
+		switchmenu_delitem(wwin->vscr->menu.root_switch, wwin);
 	} else if (strcmp(name, WMNChangedWorkspace) == 0) {
 		switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);
+		switchmenu_changeworkspaceitem(wwin->vscr->menu.root_switch, wwin);
 	} else if (strcmp(name, WMNChangedFocus) == 0) {
 		switchmenu_changestate(wwin->vscr->menu.switch_menu, wwin);
+		switchmenu_changestate(wwin->vscr->menu.root_switch, wwin);
 	} else if (strcmp(name, WMNChangedName) == 0) {
 		switchmenu_changeitem(wwin->vscr->menu.switch_menu, wwin);
+		switchmenu_changeitem(wwin->vscr->menu.root_switch, wwin);
 	} else if (strcmp(name, WMNChangedState) == 0) {
-		if (strcmp((char *)data, "omnipresent") == 0)
+		if (strcmp((char *)data, "omnipresent") == 0) {
 			switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin);
-		else
+			switchmenu_changeworkspaceitem(wwin->vscr->menu.root_switch, wwin);
+		} else {
 			switchmenu_changestate(wwin->vscr->menu.switch_menu, wwin);
+			switchmenu_changestate(wwin->vscr->menu.root_switch, wwin);
+		}
 	}
 
 	/* If menu is not mapped, exit */
@@ -425,6 +433,7 @@ static void observer(void *self, WMNotification * notif)
 		return;
 
 	menu_move_visible(wwin->vscr->menu.switch_menu);
+	menu_move_visible(wwin->vscr->menu.root_switch);
 }
 
 static void wsobserver(void *self, WMNotification *notif)
@@ -437,6 +446,8 @@ static void wsobserver(void *self, WMNotification *notif)
 	/* Parameter not used, but tell the compiler that it is ok */
 	(void) self;
 
-	if (strcmp(name, WMNWorkspaceNameChanged) == 0)
+	if (strcmp(name, WMNWorkspaceNameChanged) == 0) {
 		update_menu_workspacerename(vscr->menu.switch_menu, workspace);
+		update_menu_workspacerename(vscr->menu.root_switch, workspace);
+	}
 }

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -254,16 +254,16 @@ static void switchmenu_changeitem(virtual_screen *vscr, WWindow *wwin)
 	}
 }
 
-static void switchmenu_changeworkspaceitem(virtual_screen *vscr, WWindow *wwin)
+static void switchmenu_changeworkspaceitem(WMenu *menu, virtual_screen *vscr, WWindow *wwin)
 {
 	WMenuEntry *entry;
 	int i;
 
-	if (!vscr->menu.switch_menu)
+	if (!menu)
 		return;
 
-	for (i = 0; i < vscr->menu.switch_menu->entry_no; i++) {
-		entry = vscr->menu.switch_menu->entries[i];
+	for (i = 0; i < menu->entry_no; i++) {
+		entry = menu->entries[i];
 		/* this is the entry that was changed */
 		if (entry->clientdata == wwin) {
 			if (entry->rtext) {
@@ -285,11 +285,11 @@ static void switchmenu_changeworkspaceitem(virtual_screen *vscr, WWindow *wwin)
 				ion = entry->flags.indicator_on;
 
 				if (!IS_OMNIPRESENT(wwin) && idx < 0)
-					idx = menuIndexForWindow(vscr->menu.switch_menu, wwin, i);
+					idx = menuIndexForWindow(menu, wwin, i);
 
-				wMenuRemoveItem(vscr->menu.switch_menu, i);
+				wMenuRemoveItem(menu, i);
 
-				entry = wMenuInsertCallback(vscr->menu.switch_menu, idx, t, focusWindow, wwin);
+				entry = wMenuInsertCallback(menu, idx, t, focusWindow, wwin);
 				wfree(t);
 				entry->rtext = rt;
 				entry->flags.indicator = 1;
@@ -375,14 +375,14 @@ static void observer(void *self, WMNotification * notif)
 	} else if (strcmp(name, WMNUnmanaged) == 0) {
 		switchmenu_delitem(wwin->vscr->menu.switch_menu, wwin);
 	} else if (strcmp(name, WMNChangedWorkspace) == 0) {
-		switchmenu_changeworkspaceitem(wwin->vscr, wwin);
+		switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin->vscr, wwin);
 	} else if (strcmp(name, WMNChangedFocus) == 0) {
 		switchmenu_changestate(wwin->vscr, wwin);
 	} else if (strcmp(name, WMNChangedName) == 0) {
 		switchmenu_changeitem(wwin->vscr, wwin);
 	} else if (strcmp(name, WMNChangedState) == 0) {
 		if (strcmp((char *)data, "omnipresent") == 0)
-			switchmenu_changeworkspaceitem(wwin->vscr, wwin);
+			switchmenu_changeworkspaceitem(wwin->vscr->menu.switch_menu, wwin->vscr, wwin);
 		else
 			switchmenu_changestate(wwin->vscr, wwin);
 	}

--- a/src/switchmenu.c
+++ b/src/switchmenu.c
@@ -106,6 +106,16 @@ WMenu *switchmenu_create(virtual_screen *vscr)
 	return switch_menu;
 }
 
+void switchmenu_destroy(virtual_screen *vscr)
+{
+	if (!vscr->menu.switch_menu)
+		return;
+
+	wMenuDestroy(vscr->menu.switch_menu, True);
+	vscr->menu.switch_menu = NULL;
+	vscr->menu.flags.added_window_menu = 0;
+}
+
 /* Open switch menu */
 void OpenSwitchMenu(virtual_screen *vscr, int x, int y, int keyboard)
 {

--- a/src/switchmenu.h
+++ b/src/switchmenu.h
@@ -26,6 +26,7 @@ void switchmenu_additem(WMenu *menu, WWindow *wwin);
 void switchmenu_delitem(WMenu *menu, WWindow *wwin);
 
 WMenu *switchmenu_create(virtual_screen *vscr);
+void switchmenu_destroy(virtual_screen *vscr);
 void OpenSwitchMenu(virtual_screen *vscr, int x, int y, int keyboard);
 void InitializeSwitchMenu(void);
 

--- a/src/winspector.c
+++ b/src/winspector.c
@@ -732,12 +732,16 @@ static void applySettings(WMWidget *button, void *client_data)
 	if (WFLAGP(wwin_inspected, skip_window_list) != old_skip_window_list) {
 		virtual_screen *vscr = wwin_inspected->vscr;
 
-		if (WFLAGP(wwin_inspected, skip_window_list))
+		if (WFLAGP(wwin_inspected, skip_window_list)) {
 			switchmenu_delitem(vscr->menu.switch_menu, wwin_inspected);
-		else
+			switchmenu_delitem(vscr->menu.root_switch, wwin_inspected);
+		} else {
 			switchmenu_additem(vscr->menu.switch_menu, wwin_inspected);
+			switchmenu_additem(vscr->menu.root_switch, wwin_inspected);
+		}
 
 		menu_move_visible(vscr->menu.switch_menu);
+		menu_move_visible(vscr->menu.root_switch);
 	} else {
 		if (WFLAGP(wwin_inspected, omnipresent) != old_omnipresent)
 			WMPostNotificationName(WMNChangedState, wwin_inspected, "omnipresent");


### PR DESCRIPTION
This patches creates the rootmenu and switchmenu only when the user request the menus.

The menus are not created when awaker starts and the pointers are empty.