### PR TITLE
Comment in the miniwindow.h

### DIFF
--- a/src/miniwindow.h
+++ b/src/miniwindow.h
@@ -27,7 +27,7 @@
 typedef struct WMiniWindow {
 	struct WIcon *icon;        /* Window icon when miminized else is NULL! */
 	int icon_x, icon_y;        /* Position of the icon */
-	int icon_w, icon_h;
+	int icon_w, icon_h;        /* Used by minimize animation */
 	RImage *net_icon_image;    /* Window Image */
 } WMiniWindow;
 


### PR DESCRIPTION
This patch includes the comment about the miniwindow
icon_w and icon_h, used in the minimization process.