### PR TITLE
Move variables from header

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -18,8 +18,10 @@
  */
 
 #include <X11/Xutil.h>
-
 #include "input.h"
+
+unsigned int _NumLockMask;
+unsigned int _ScrollLockMask;
 
 /* Keyboard functions */
 #ifdef NUMLOCK_HACK

--- a/src/input.h
+++ b/src/input.h
@@ -23,8 +23,8 @@
 #include "wconfig.h"
 
 /* Keyboard definitions */
-unsigned int _NumLockMask;
-unsigned int _ScrollLockMask;
+extern unsigned int _NumLockMask;
+extern unsigned int _ScrollLockMask;
 
 /* Keyboard functions */
 void wHackedGrabButton(Display *dpy, unsigned int button, unsigned int modifiers,


### PR DESCRIPTION
This patch moves two variables from the header file to the .c file,
to avoid linker problems.